### PR TITLE
sahara_run: properly propagate error

### DIFF
--- a/sahara.c
+++ b/sahara.c
@@ -235,5 +235,5 @@ int sahara_run(struct qdl_device *qdl, char *prog_mbn)
 		}
 	}
 
-	return 0;
+	return done ? 0 : -1;
 }


### PR DESCRIPTION
We should return in case we haven't reached the end of the Sahara
init, which is when we set done to true. If done is not set to true
before returning from sahara_run() , it means something went wrong.

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>