### PR TITLE
feat: expose read and write timeouts to the user

### DIFF
--- a/qdl.h
+++ b/qdl.h
@@ -10,9 +10,9 @@
 struct qdl_device;
 
 int qdl_read(struct qdl_device *qdl, void *buf, size_t len, unsigned int timeout);
-int qdl_write(struct qdl_device *qdl, const void *buf, size_t len, bool eot);
+int qdl_write(struct qdl_device *qdl, const void *buf, size_t len, bool eot, unsigned int timeout);
 
-int firehose_run(struct qdl_device *qdl, const char *incdir, const char *storage);
+int firehose_run(struct qdl_device *qdl, const char *incdir, const char *storage, unsigned int read_timeout, unsigned int write_timeout);
 int sahara_run(struct qdl_device *qdl, char *prog_mbn);
 void print_hex_dump(const char *prefix, const void *buf, size_t len);
 unsigned attr_as_unsigned(xmlNode *node, const char *attr, int *errors);

--- a/ufs.c
+++ b/ufs.c
@@ -264,9 +264,9 @@ int ufs_load(const char *ufs_file, bool finalize_provisioning)
 }
 
 int ufs_provisioning_execute(struct qdl_device *qdl,
-	int (*apply_ufs_common)(struct qdl_device *, struct ufs_common*),
-	int (*apply_ufs_body)(struct qdl_device *, struct ufs_body*),
-	int (*apply_ufs_epilogue)(struct qdl_device *, struct ufs_epilogue*, bool))
+	int (*apply_ufs_common)(struct qdl_device *, struct ufs_common*, unsigned int, unsigned int),
+	int (*apply_ufs_body)(struct qdl_device *, struct ufs_body*, unsigned int, unsigned int),
+	int (*apply_ufs_epilogue)(struct qdl_device *, struct ufs_epilogue*, bool, unsigned int, unsigned int))
 {
 	int ret;
 	struct ufs_body *body;


### PR DESCRIPTION
Added additional, optional CLI arguments to expose the timeouts
for reading and writing to the end user.  Hardcoded timeouts can
sometimes fail for large flashes.