### PR TITLE
util: allow hexadecimal values for attr_as_unsigned (fix ufs provisioning)

### DIFF
--- a/util.c
+++ b/util.c
@@ -91,7 +91,7 @@ unsigned attr_as_unsigned(xmlNode *node, const char *attr, int *errors)
 		return 0;
 	}
 
-	return (unsigned int) strtoul((char*)value, NULL, 10);
+	return (unsigned int) strtoul((char*)value, NULL, 0);
 }
 
 const char *attr_as_string(xmlNode *node, const char *attr, int *errors)


### PR DESCRIPTION
dc61f8f79e924 broke ufs provisioning by requiring base 10 for unsigned
attributes (provisioning xml have some values in hexadecimal). strtoul()
would return 0 for some values and provisioning would fail strangely.

This should resolve https://github.com/andersson/qdl/issues/3