### PR TITLE
qdl: Add support for UFS3.1 parameters

### DIFF
--- a/firehose.c
+++ b/firehose.c
@@ -507,6 +507,10 @@ int firehose_apply_ufs_common(struct qdl_device *qdl, struct ufs_common *ufs)
 	xml_setpropf(node_to_send, "wPeriodicRTCUpdate", "%d", ufs->wPeriodicRTCUpdate);
 	xml_setpropf(node_to_send, "bConfigDescrLock", "%d", 0/*ufs->bConfigDescrLock*/); //Safety, remove before fly
 
+	xml_setpropf(node_to_send, "bWriteBoosterBufferPreserveUserSpaceEn", "%d", ufs->bWriteBoosterBufferPreserveUserSpaceEn);
+	xml_setpropf(node_to_send, "bWriteBoosterBufferType", "%d", ufs->bWriteBoosterBufferType);
+	xml_setpropf(node_to_send, "shared_wb_buffer_size_in_qb", "%d", ufs->shared_wb_buffer_size_in_kb);
+
 	ret = firehose_send_single_tag(qdl, node_to_send);
 	if (ret)
 		fprintf(stderr, "[APPLY UFS common] %d\n", ret);

--- a/ufs.c
+++ b/ufs.c
@@ -79,6 +79,9 @@ struct ufs_common *ufs_parse_common_params(xmlNode *node, bool finalize_provisio
 	result->bInitActiveICCLevel = attr_as_unsigned(node, "bInitActiveICCLevel", &errors);
 	result->wPeriodicRTCUpdate = attr_as_unsigned(node, "wPeriodicRTCUpdate", &errors);
 	result->bConfigDescrLock = !!attr_as_unsigned(node, "bConfigDescrLock", &errors);
+	result->bWriteBoosterBufferPreserveUserSpaceEn = !!attr_as_unsigned(node, "bWriteBoosterBufferPreserveUserSpaceEn", &errors);
+	result->bWriteBoosterBufferType = attr_as_unsigned(node, "bWriteBoosterBufferType", &errors);
+	result->shared_wb_buffer_size_in_kb = attr_as_unsigned(node, "shared_wb_buffer_size_in_kb", &errors);
 
 	if (errors) {
 		fprintf(stderr, "[UFS] errors while parsing common\n");

--- a/ufs.h
+++ b/ufs.h
@@ -42,6 +42,9 @@ struct ufs_common {
 	unsigned	bInitActiveICCLevel;
 	unsigned	wPeriodicRTCUpdate;
 	bool		bConfigDescrLock;
+	bool		bWriteBoosterBufferPreserveUserSpaceEn;
+	unsigned	bWriteBoosterBufferType;
+	unsigned	shared_wb_buffer_size_in_kb;
 };
 
 struct ufs_body {


### PR DESCRIPTION
WriteBooster is a mandatory feature on UFS 3.1 and required for provisioning.
Add the XML fields for the firehose.

Signed-off-by: Jordan Crouse <jorcrous@amazon.com>