### PR TITLE
readme: Mention libudev requirement

### DIFF
--- a/README
+++ b/README
@@ -9,8 +9,8 @@ Usage:
 
 Building
 ========
-In order to build the project you need libxml2 headers and libraries, found in
-e.g. the libxml2-dev package.
+In order to build the project you need libxml2 and libudev headers
+and libraries, found in e.g. the libxml2-dev and libudev-dev packages
 
-With this installed run:
+With these installed run:
   make


### PR DESCRIPTION
Without libudev installed you'll get the following build error:

    qdl.c:43:10: fatal error: libudev.h: No such file or directory
       43 | #include <libudev.h>
          |          ^~~~~~~~~~~
    compilation terminated.
    make: *** [<builtin>: qdl.o] Error 1

Mention the ubuntu package that brings it in as well similar to how
libxml2 is mentioned.

Signed-off-by: Andrew Halaney <ajhalaney@gmail.com>