### PR TITLE
qdl: Add a fix for read xml error

### DIFF
--- a/program.c
+++ b/program.c
@@ -97,7 +97,9 @@ static int load_program_tag(xmlNode *node, bool is_nand)
 
 	if (is_nand) {
 		program->pages_per_block = attr_as_unsigned(node, "PAGES_PER_BLOCK", &errors);
-		program->last_sector = attr_as_unsigned(node, "last_sector", &errors);
+		if (NULL != xmlGetProp(node, (xmlChar *)"last_sector")) {
+			program->last_sector = attr_as_unsigned(node, "last_sector", &errors);
+		}
 	} else {
 		program->file_offset = attr_as_unsigned(node, "file_sector_offset", &errors);
 	}


### PR DESCRIPTION
When xml has no last_sector, qdl will read xml failed. Add check
to see if last_sector exists